### PR TITLE
Fix google analytics anonymize always true

### DIFF
--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -207,7 +207,7 @@ class Ga extends \Magento\Framework\View\Element\Template
     {
         return [
             'optPageUrl' => $this->getOptPageUrl(),
-            'isAnonymizedIpActive' => $this->_googleAnalyticsData->isAnonymizedIpActive(),
+            'isAnonymizedIpActive' => !!$this->_googleAnalyticsData->isAnonymizedIpActive(),
             'accountId' => $this->escapeHtmlAttr($accountId, false)
         ];
     }


### PR DESCRIPTION
The isAnonymizedIpActive value needs to be convert to boolean.
This fix this javascript statement "if (config.pageTrackingData.isAnonymizedIpActive)" that will always return true if compare to "0" and "1".
